### PR TITLE
Simplify recommended hbase-site.xml

### DIFF
--- a/content/setup-hbase.content
+++ b/content/setup-hbase.content
@@ -37,18 +37,6 @@ cat &gt;conf/hbase-site.xml &lt;&lt;EOF
     &lt;name&gt;hbase.rootdir&lt;/name&gt;
     &lt;value&gt;file:///$hbase_rootdir/hbase-\${user.name}/hbase&lt;/value&gt;
   &lt;/property&gt;
-  &lt;property&gt;
-    &lt;name&gt;hbase.zookeeper.dns.interface&lt;/name&gt;
-    &lt;value&gt;$iface&lt;/value&gt;
-  &lt;/property&gt;
-  &lt;property&gt;
-    &lt;name&gt;hbase.regionserver.dns.interface&lt;/name&gt;
-    &lt;value&gt;$iface&lt;/value&gt;
-  &lt;/property&gt;
-  &lt;property&gt;
-    &lt;name&gt;hbase.master.dns.interface&lt;/name&gt;
-    &lt;value&gt;$iface&lt;/value&gt;
-  &lt;/property&gt;
 &lt;/configuration&gt;
 EOF
 </div>


### PR DESCRIPTION
Adjust the OpenTSDB recommendation to match the hbase documentation.
The OpenTSDB recommended `hbase-site.xml` didn't work with hbase-0.95.
http://hbase.apache.org/book/quickstart.html suggests a much shorter
`hbase-site.xml`.

I have, just now, filed an OpenTSDB Contributor License Agreement.
- Bruce
