### PR TITLE
fix github repo reference

### DIFF
--- a/contributing.html
+++ b/contributing.html
@@ -45,7 +45,7 @@ Get a better, modern browsing experience with
 
 A few guidelines to keep in mind:
 <ul>
-<li>Please file <a href="https://github.com/stumbleupon/opentsdb/issues">
+<li>Please file <a href="https://github.com/OpenTSDB/opentsdb/issues">
 issues on GitHub</a>.  Make sure your bug reports contain enough details
 so they can be easily understood by others and quickly fixed.</li>
 <li>The best way to contribute code is to

--- a/faq.html
+++ b/faq.html
@@ -237,7 +237,7 @@ Mostly because OpenTSDB lives around the HBase community, which is a Java
 community.  OpenTSDB also started by using HBase's library, which only
 exists in Java.  Eventually, however, OpenTSDB started to use another
 alternative library to access HBase
-(<a href="http://github.com/stumbleupon/asynchbase">asynchbase</a>)
+(<a href="http://github.com/OpenTSDB/asynchbase">asynchbase</a>)
 but sadly this one too is in Java.
 
 <h4>Can I use OpenTSDB to generate graphs for my customers / end-users?</h4>
@@ -261,13 +261,13 @@ too ambiguous, and the author miserably failed to come up with a better name.
 OpenTSDB was originally designed and implemented at
 <a href="http://www.stumbleupon.com">StumbleUpon</a> by Beno&icirc;t Sigoure.
 Berk D. Demir contributed ideas and feedback during the early design stages.
-<a href="https://github.com/stumbleupon/tcollector"><code>tcollector</code></a>
+<a href="https://github.com/OpenTSDB/tcollector"><code>tcollector</code></a>
 was designed and implemented by Mark Smith and Dave
 Barr, with contributions from Beno&icirc;t Sigoure.
 
 <h4>How to contribute to OpenTSDB?</h4>
 The easiest way is to <a href="http://help.github.com/fork-a-repo/">fork</a>
-the project on <a href="https://github.com/stumbleupon/opentsdb">GitHub</a>.
+the project on <a href="https://github.com/OpenTSDB/opentsdb">GitHub</a>.
 Make whatever changes you want to your own fork, then send a
 <a href="http://help.github.com/send-pull-requests/">pull request</a>.
 You can also send your patches to the

--- a/getting-started.html
+++ b/getting-started.html
@@ -65,12 +65,12 @@ OpenTSDB comes pre-packaged with all the necessary dependencies except the
 JDK and Gnuplot.<br/>The runtime dependencies for OpenTSDB are:
 <ul>
 <li>JDK 1.6</li>
-<li><a href="http://github.com/stumbleupon/asynchbase">asynchbase</a> 1.3.0 (BSD)</li>
+<li><a href="http://github.com/OpenTSDB/asynchbase">asynchbase</a> 1.3.0 (BSD)</li>
 <li><a href="http://code.google.com/p/guava-libraries/">Guava</a> 12.0 (ASLv2)</li>
 <li><a href="http://logback.qos.ch/">logback</a> 1.0 (LGPLv2.1 / EPL)</li>
 <li><a href="http://jboss.org/netty">Netty</a> 3.4 (ASLv2)</li>
 <li><a href="http://slf4j.org">SLF4J</a> 1.6 (MIT) with Log4J and JCL adapters</li>
-<li><a href="http://github.com/stumbleupon/async">suasync</a> 1.2 (BSD)</li>
+<li><a href="http://github.com/OpenTSDB/async">suasync</a> 1.2 (BSD)</li>
 <li><a href="http://hadoop.apache.org/zookeeper/">ZooKeeper</a> 3.3 (ASLv2)</li>
 </ul>
 You need to have <a href="http://www.gnuplot.info/">Gnuplot</a> (custom
@@ -96,7 +96,7 @@ followed by <code>./configure</code> and <code>make</code>.  There is a
 handy shell script named <code>build.sh</code> that will take care of all
 of that for you, and build OpenTSDB in a new subdirectory named
 <code>build</code>:
-<div class="code">git clone git://github.com/stumbleupon/opentsdb.git
+<div class="code">git clone git://github.com/OpenTSDB/opentsdb.git
 cd opentsdb
 ./build.sh
 </div>
@@ -154,7 +154,7 @@ now if you have a large site.
 So now that we have our 2 metrics, we can start sending data do the TSD.
 Let's write a little shell script to collect some data off of MySQL and
 send it to the TSD (note: this is just an example, in practice you can
-use <a href="https://github.com/stumbleupon/tcollector/blob/master/collectors/0/mysql.py">tcollector's MySQL collector</a>.):
+use <a href="https://github.com/OpenTSDB/tcollector/blob/master/collectors/0/mysql.py">tcollector's MySQL collector</a>.):
 <div class="code">cat &gt;mysql-collector.sh &lt;&lt;\EOF
 #!/bin/bash
 set -e
@@ -202,7 +202,7 @@ and the current hostname.  Rinse and repeat every 15 seconds.  The <code>-w
 connection to the TSD.
 <p>
 Bear in mind, this is just an example, in practice you can use
-<a href="https://github.com/stumbleupon/tcollector/blob/master/collectors/0/mysql.py">tcollector's MySQL collector</a>.
+<a href="https://github.com/OpenTSDB/tcollector/blob/master/collectors/0/mysql.py">tcollector's MySQL collector</a>.
 <p>
 If you don't have a MySQL server to monitor, you can try this instead to
 collect basic load metrics from your Linux servers.

--- a/http-api.html
+++ b/http-api.html
@@ -47,7 +47,7 @@ Get a better, modern browsing experience with
 This document is a draft specification of the HTTP API exposed by the TSD
 (Time Series Daemon).  OpenTSDB is still in beta, so this specification is
 subject to changes.  This specification is current as of
-<a href="https://github.com/stumbleupon/opentsdb/commit/f33d77416017802bb4c3001aa9581db7feced3d6">December 4, 2010</a>.
+<a href="https://github.com/OpenTSDB/opentsdb/commit/f33d77416017802bb4c3001aa9581db7feced3d6">December 4, 2010</a>.
 The excerpts of HTTP queries in this document have been intentionally
 simplified, e.g. by removing some headers in the responses or not specifying
 the HTTP protocol version in the requests (HTTP 1.1 is assumed throughout).
@@ -56,7 +56,7 @@ the HTTP protocol version in the requests (HTTP 1.1 is assumed throughout).
 <h3>Generalities</h3>
 
 The code that dispatches all requests is in
-<a href="https://github.com/stumbleupon/opentsdb/blob/b85f7602872ecefda7b2a8b35e79681473f74130/src/tsd/RpcHandler.java">
+<a href="https://github.com/OpenTSDB/opentsdb/blob/b85f7602872ecefda7b2a8b35e79681473f74130/src/tsd/RpcHandler.java">
 <code>RpcHandler.java</code></a>.  Some HTTP end-points can return results
 in 3 different formats:
 <ul>
@@ -136,7 +136,7 @@ strings and all the strings are returned in an array.
 <p>
 The number of log messages returned depends on the configuration of the
 cyclic buffer in
-<a href="https://github.com/stumbleupon/opentsdb/blob/master/src/logback.xml"><code>src/logback.xml</code></a>.
+<a href="https://github.com/OpenTSDB/opentsdb/blob/master/src/logback.xml"><code>src/logback.xml</code></a>.
 
 <p>
 Passing a <code>level</code> query string parameter will instead change the

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@ At StumbleUpon, we have found this system tremendously helpful to:
 </ul>
 <p>
 OpenTSDB is free software and
-<a href="https://github.com/stumbleupon/opentsdb">is available</a> under the
+<a href="https://github.com/OpenTSDB/opentsdb">is available</a> under the
 LGPLv2.1+ license.
 <p>
 Join the OpenTSDB mailing list:

--- a/overview.html
+++ b/overview.html
@@ -60,7 +60,7 @@ to one of the TSDs every few seconds.
 <p>
 <a href="http://www.stumbleupon.com">StumbleUpon</a> wrote a Python framework
 called
-<a href="https://github.com/stumbleupon/tcollector"><strong><code>tcollector</code></strong></a>
+<a href="https://github.com/OpenTSDB/tcollector"><strong><code>tcollector</code></strong></a>
 that we use to collect
 thousand of metrics from Linux 2.6, Apache's HTTPd, MySQL, HBase, memcached,
 Varnish and more.  This framework comes with a number of Linux collectors and

--- a/schema.html
+++ b/schema.html
@@ -65,19 +65,19 @@ And the metric ID for <code>myservice.latency.avg</code> is
 </div>
 (note that the bytes for the timestamp are <code>[77, 4, -99, 32]</code> =
 1292148000, because timestamps in the row key are rounded down to a
-<a href="https://github.com/stumbleupon/opentsdb/blob/25078599673e357c20f3ca0b354079141aaf1345/src/core/Const.java#L38">60
+<a href="https://github.com/OpenTSDB/opentsdb/blob/25078599673e357c20f3ca0b354079141aaf1345/src/core/Const.java#L38">60
 minute</a> boundary)
 
 <p/>
 Then the column qualifier for the value is on 2 bytes (16 bits).  The
 first 12 bits are used to store an integer which is a delta in seconds
 from the timestamp in the row key, and the remaining
-<a href="https://github.com/stumbleupon/opentsdb/blob/b2b9fac7e378b22f2e038bfb69f9baf724db782e/src/core/Const.java#L26">4 bits</a>
+<a href="https://github.com/OpenTSDB/opentsdb/blob/b2b9fac7e378b22f2e038bfb69f9baf724db782e/src/core/Const.java#L26">4 bits</a>
 are flags.  In the example above, the data point is at time 1292148123 but
 the timestamp in the row key is 1292148000, so the delta is 123.  The 4 bits
 of flag are used as follows: the first bit indicates whether the value is an
 integer value or a floating point value
-(<a href="https://github.com/stumbleupon/opentsdb/blob/b2b9fac7e378b22f2e038bfb69f9baf724db782e/src/core/Const.java#L29"><code>Const.FLAG_FLOAT</code></a>),
+(<a href="https://github.com/OpenTSDB/opentsdb/blob/b2b9fac7e378b22f2e038bfb69f9baf724db782e/src/core/Const.java#L29"><code>Const.FLAG_FLOAT</code></a>),
 the remaining 3 bits aren't really used at this time (as of 2010-12-21), but
 they're reserved for variable-length encoding in the future.
 <p/>
@@ -85,7 +85,7 @@ The value in the cell is the value of the data point itself, on 8 bytes.
 
 <p/>
 The code that adds new data to HBase is in
-<a href="https://github.com/stumbleupon/opentsdb/blob/master/src/core/IncomingDataPoints.java#L35"><code>core.IncomingDataPoints</code></a>,
+<a href="https://github.com/OpenTSDB/opentsdb/blob/master/src/core/IncomingDataPoints.java#L35"><code>core.IncomingDataPoints</code></a>,
 so you can refer to this if you want to get down to the implementation
 details.  You can also examine the raw contents of your table using the
 <code>scan</code> <a href="cli.html">command-line tool</a>, for instance:


### PR DESCRIPTION
Fixed  references to the _new_ github repository that is now located at https://github.com/OpenTSDB
