### PR TITLE
correct typo

### DIFF
--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -14,7 +14,7 @@ properties start with ``tsd.`` Comments or inactive configuration lines are
 blocked by a hash symbol ``#``. For example::
 
   # List of Zookeeper hosts that manage the HBase cluster
-  tsd.storage.hbase.zk_quorum - 192.168.1.100
+  tsd.storage.hbase.zk_quorum = 192.168.1.100
   
 will configure the TSD to connect to Zookeeper on ``192.168.1.100``.
 


### PR DESCRIPTION
help document " Each name is followed by an equals sign " but the example is minus sign, so i correct this typo and please `make html` again to renew it. 
