### PR TITLE
resources.rst amendment with docker image information

### DIFF
--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -3,6 +3,10 @@ Additional Resources
 
 These are just some of the awesome front-ends, utilities, libraries and resources created by the OpenTSDB community. Please let us know if you have a project you'd like to see listed and if you don't see something you need, search for it on Github (new projects are popping up all the time) or your favorite search engine.
 
+Docker Images
+^^^^^^^^^^^^^
+* `petergrace/opentsdb-docker <https://registry.hub.docker.com/u/petergrace/opentsdb-docker/>`_ - A prebuilt Docker image with HBase and OpenTSDB already configured and ready to run!  If you have Docker installed, execute ``docker run -d -p 4242:4242 petergrace/opentsdb-docker`` to create an opentsdb instance running on port 4242.
+
 Front Ends
 ^^^^^^^^^^
 


### PR DESCRIPTION
ManOLamancha on the google group mentioned that I should update resources.rst with information on the Docker image I composed.  Without guidance on where to place the information, I assumed that it would be best to have it at the top of the file due to its ability to provide an entire opentsdb environment with one command.  Please feel free to relocate if this was not appropriate.
