### PR TITLE
Correct suggest docs - q is optional

### DIFF
--- a/docs/build/html/_sources/api_http/index.txt
+++ b/docs/build/html/_sources/api_http/index.txt
@@ -6,7 +6,7 @@ OpenTSDB provides an HTTP based application programming interface to enable inte
 Overview
 --------
 
-The HTTP API is RESTful in nature but provides alternative access through various overrides since not all clients can adhere to a strict REST protocol. The default data exchange is via JSON though plugable ``formatters`` may be accessed, via the request, to send or receive data in different formats. Standard HTTP response codes are used for all returned results and errors will be returned as content using the proper format.
+The HTTP API is RESTful in nature but provides alternative access through various overrides since not all clients can adhere to a strict REST protocol. The default data exchange is via JSON though pluggable ``formatters`` may be accessed, via the request, to send or receive data in different formats. Standard HTTP response codes are used for all returned results and errors will be returned as content using the proper format.
 
 Version 1.X to 2.x
 ------------------
@@ -16,7 +16,7 @@ OpenTSDB 1.x had a simple HTTP API that provided access to common behaviors such
 Serializers
 -----------
 
-2.0 introduces plugable serializers that allow for parsing user input and returning results in different formats such as XML or JSON. Serializers only apply to the 2.0 API calls, all 1.0 behave as before. For details on Serializers and options supported, please read :doc:`serializers/index`
+2.0 introduces pluggable serializers that allow for parsing user input and returning results in different formats such as XML or JSON. Serializers only apply to the 2.0 API calls, all 1.0 behave as before. For details on Serializers and options supported, please read :doc:`serializers/index`
 
 All API calls use the default JSON serializer unless overridden by query string or ``Content-Type`` header. To override:
 

--- a/docs/build/html/_sources/new.txt
+++ b/docs/build/html/_sources/new.txt
@@ -8,7 +8,7 @@ OpenTSDB has a thriving community who contributed and requested a number of new 
 * Cross Origin Resource Sharing - For the API so you can make AJAX calls easily
 * Store Data Via HTTP - Write data points over HTTP as an alternative to Telnet
 * Configuration File - A key/value file shared by the TSD and command line tools
-* Plugable Serializers - Enable different inputs and outputs for the API
+* Pluggable Serializers - Enable different inputs and outputs for the API
 * Annotations - Record meta data about specific time series or data points
 * Meta Data - Record meta data for each time series, metrics, tag names, or values
 * Trees - Flatten metric and tag combinations into a single name for navigation or usage with different tools

--- a/docs/build/html/api_http/index.html
+++ b/docs/build/html/api_http/index.html
@@ -112,7 +112,7 @@
 <p>OpenTSDB provides an HTTP based application programming interface to enable integration with external systems. Almost all OpenTSDB features are accessiable via the API such as querying timeseries data, managing metadata and storing data points. Please read this entire page for important information about standard API behavior before investigating individual endpoints.</p>
 <div class="section" id="overview">
 <h2>Overview</h2>
-<p>The HTTP API is RESTful in nature but provides alternative access through various overrides since not all clients can adhere to a strict REST protocol. The default data exchange is via JSON though plugable <tt class="docutils literal"><span class="pre">formatters</span></tt> may be accessed, via the request, to send or receive data in different formats. Standard HTTP response codes are used for all returned results and errors will be returned as content using the proper format.</p>
+<p>The HTTP API is RESTful in nature but provides alternative access through various overrides since not all clients can adhere to a strict REST protocol. The default data exchange is via JSON though pluggable <tt class="docutils literal"><span class="pre">formatters</span></tt> may be accessed, via the request, to send or receive data in different formats. Standard HTTP response codes are used for all returned results and errors will be returned as content using the proper format.</p>
 </div>
 <div class="section" id="version-1-x-to-2-x">
 <h2>Version 1.X to 2.x</h2>
@@ -120,7 +120,7 @@
 </div>
 <div class="section" id="serializers">
 <h2>Serializers</h2>
-<p>2.0 introduces plugable serializers that allow for parsing user input and returning results in different formats such as XML or JSON. Serializers only apply to the 2.0 API calls, all 1.0 behave as before. For details on Serializers and options supported, please read <a class="reference internal" href="serializers/index.html"><em>HTTP Serializers</em></a></p>
+<p>2.0 introduces pluggable serializers that allow for parsing user input and returning results in different formats such as XML or JSON. Serializers only apply to the 2.0 API calls, all 1.0 behave as before. For details on Serializers and options supported, please read <a class="reference internal" href="serializers/index.html"><em>HTTP Serializers</em></a></p>
 <p>All API calls use the default JSON serializer unless overridden by query string or <tt class="docutils literal"><span class="pre">Content-Type</span></tt> header. To override:</p>
 <ul>
 <li><p class="first"><strong>Query String</strong> - Supply a parameter such as <tt class="docutils literal"><span class="pre">serializer=&lt;serializer_name&gt;</span></tt> where <tt class="docutils literal"><span class="pre">&lt;serializer_name&gt;</span></tt> is the hard-coded name of the serializer as shown in the <tt class="docutils literal"><span class="pre">/api/serializers</span></tt> <tt class="docutils literal"><span class="pre">serializer</span></tt> output field.</p>

--- a/docs/build/html/new.html
+++ b/docs/build/html/new.html
@@ -93,7 +93,7 @@
 <li>Cross Origin Resource Sharing - For the API so you can make AJAX calls easily</li>
 <li>Store Data Via HTTP - Write data points over HTTP as an alternative to Telnet</li>
 <li>Configuration File - A key/value file shared by the TSD and command line tools</li>
-<li>Plugable Serializers - Enable different inputs and outputs for the API</li>
+<li>Pluggable Serializers - Enable different inputs and outputs for the API</li>
 <li>Annotations - Record meta data about specific time series or data points</li>
 <li>Meta Data - Record meta data for each time series, metrics, tag names, or values</li>
 <li>Trees - Flatten metric and tag combinations into a single name for navigation or usage with different tools</li>

--- a/docs/source/api_http/index.rst
+++ b/docs/source/api_http/index.rst
@@ -6,7 +6,7 @@ OpenTSDB provides an HTTP based application programming interface to enable inte
 Overview
 --------
 
-The HTTP API is RESTful in nature but provides alternative access through various overrides since not all clients can adhere to a strict REST protocol. The default data exchange is via JSON though plugable ``formatters`` may be accessed, via the request, to send or receive data in different formats. Standard HTTP response codes are used for all returned results and errors will be returned as content using the proper format.
+The HTTP API is RESTful in nature but provides alternative access through various overrides since not all clients can adhere to a strict REST protocol. The default data exchange is via JSON though pluggable ``formatters`` may be accessed, via the request, to send or receive data in different formats. Standard HTTP response codes are used for all returned results and errors will be returned as content using the proper format.
 
 Version 1.X to 2.x
 ------------------
@@ -16,7 +16,7 @@ OpenTSDB 1.x had a simple HTTP API that provided access to common behaviors such
 Serializers
 -----------
 
-2.0 introduces plugable serializers that allow for parsing user input and returning results in different formats such as XML or JSON. Serializers only apply to the 2.0 API calls, all 1.0 behave as before. For details on Serializers and options supported, please read :doc:`serializers/index`
+2.0 introduces pluggable serializers that allow for parsing user input and returning results in different formats such as XML or JSON. Serializers only apply to the 2.0 API calls, all 1.0 behave as before. For details on Serializers and options supported, please read :doc:`serializers/index`
 
 All API calls use the default JSON serializer unless overridden by query string or ``Content-Type`` header. To override:
 

--- a/docs/source/api_http/suggest.rst
+++ b/docs/source/api_http/suggest.rst
@@ -17,7 +17,7 @@ Requests
    :widths: 10, 5, 5, 45, 10, 5, 5, 15
    
    "type", "String", "Required", "The type of data to auto complete on. Must be one of the following: **metrics**, **tagk** or **tagv**", "", "type", "", "metrics"
-   "q", "String", "Required", "A string to match on for the given type", "", "q", "", "web"
+   "q", "String", "Optional", "A string to match on for the given type", "", "q", "", "web"
    "max", "Integer", "Optional", "The maximum number of suggested results to return. Must be greater than 0", "25", "max", "", "10"
 
 Example Request

--- a/docs/source/new.rst
+++ b/docs/source/new.rst
@@ -8,7 +8,7 @@ OpenTSDB has a thriving community who contributed and requested a number of new 
 * Cross Origin Resource Sharing - For the API so you can make AJAX calls easily
 * Store Data Via HTTP - Write data points over HTTP as an alternative to Telnet
 * Configuration File - A key/value file shared by the TSD and command line tools
-* Plugable Serializers - Enable different inputs and outputs for the API
+* Pluggable Serializers - Enable different inputs and outputs for the API
 * Annotations - Record meta data about specific time series or data points
 * Meta Data - Record meta data for each time series, metrics, tag names, or values
 * Trees - Flatten metric and tag combinations into a single name for navigation or usage with different tools


### PR DESCRIPTION
The docs currently indicate that q is mandatory on suggest calls, but when I was looking at the code I noticed it's optional - which I think is a good thing, so I think we should fix the docs.
