### PR TITLE
Typo (s/COllectd/Collectd)

### DIFF
--- a/overview.html
+++ b/overview.html
@@ -79,7 +79,7 @@ that is used to collect
 thousand of metrics from Linux 2.6, Apache's HTTPd, MySQL, HBase, memcached,
 Varnish and more.  This low-impact framework includes a number useful collectors 
 and the community is constantly providing more. Alternative frameworks with OpenTSDB
-support include COllectd, Statsd and the Coda Hale metrics emitter.</a>.
+support include Collectd, Statsd and the Coda Hale metrics emitter.</a>.
 <p>
 In OpenTSDB, a time series data point consists of:
 <ul>


### PR DESCRIPTION
Hi, I believe collectd is usually called collectd or Collectd.
