### PR TITLE
Remove white-space in user_guide/configuration

### DIFF
--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -104,7 +104,7 @@ documentation for details.
    "tsd.storage.hbase.uid_table", "String", "Optional", "Name of the HBase table where UID information is stored", "tsdb-uid", "--uidtable"
    "tsd.storage.hbase.zk_basedir", "String", "Optional", "Path under which the znode for the -ROOT- region is located", "/hbase", "--zkbasedir"
    "tsd.storage.hbase.zk_quorum", "String", "Optional", "A comma-separated list of ZooKeeper hosts to connect to, with or without port specifiers.
-   E.g. ``192.168.1.1:2181, 192.168.1.2:2181``", "localhost", "--zkquorum"
+   E.g. ``192.168.1.1:2181,192.168.1.2:2181``", "localhost", "--zkquorum"
    
 Data Types
 ^^^^^^^^^^


### PR DESCRIPTION
Commit removes white-space in user_guide/configuration in example for
tsd.storage.hbase.zk_quorum, because it's no white-space in real-life OTSDB
configuration. Therefore, it's confusing to show one in documentation.
