### PR TITLE
Correction about smoothing the graph

### DIFF
--- a/docs/build/html/user_guide/guis/index.html
+++ b/docs/build/html/user_guide/guis/index.html
@@ -223,7 +223,7 @@
 </div>
 <div class="section" id="style-tab">
 <h3>Style Tab</h3>
-<p>The style tab currently has a single box, the <strong>Smooth</strong> check box. With this checked, the data point characters will be removed from the graph showing the lines only. Some users prefer this over the default.</p>
+<p>The style tab currently has a single box, the <strong>Smooth</strong> check box. With this checked, the data point characters will be removed from the graph (showing the lines only) and the data will be smoothed with splines (at least three points need to be plotted). Some users prefer this over the default.</p>
 <img alt="../../_images/gui_smooth.png" src="../../_images/gui_smooth.png" />
 </div>
 </div>


### PR DESCRIPTION
It was incorrectly stated that only the marks were removed, but, even if I honestly didn't check the sources, it cannot be: with two points I can get normal graphs with marks, but I get an error when I enable smoothing: "at least three points are required for splines".
