### PR TITLE
Changed web01,web02,web03 to web1,web2,web3 to match rest of docs

### DIFF
--- a/docs/build/html/user_guide/query/examples.html
+++ b/docs/build/html/user_guide/query/examples.html
@@ -127,47 +127,47 @@
 <tbody valign="top">
 <tr class="row-even"><td>1</td>
 <td>sys.cpu.system</td>
-<td>dc=dal host=web01</td>
+<td>dc=dal host=web1</td>
 <td>0102040101</td>
 </tr>
 <tr class="row-odd"><td>2</td>
 <td>sys.cpu.system</td>
-<td>dc=dal host=web02</td>
+<td>dc=dal host=web2</td>
 <td>0102040102</td>
 </tr>
 <tr class="row-even"><td>3</td>
 <td>sys.cpu.system</td>
-<td>dc=dal host=web03</td>
+<td>dc=dal host=web3</td>
 <td>0102040103</td>
 </tr>
 <tr class="row-odd"><td>4</td>
 <td>sys.cpu.system</td>
-<td>host=web01</td>
+<td>host=web1</td>
 <td>010101</td>
 </tr>
 <tr class="row-even"><td>5</td>
 <td>sys.cpu.system</td>
-<td>host=web01 owner=jdoe</td>
+<td>host=web1 owner=jdoe</td>
 <td>0101010306</td>
 </tr>
 <tr class="row-odd"><td>6</td>
 <td>sys.cpu.system</td>
-<td>dc=lax host=web01</td>
+<td>dc=lax host=web1</td>
 <td>0102050101</td>
 </tr>
 <tr class="row-even"><td>7</td>
 <td>sys.cpu.system</td>
-<td>dc=lax host=web02</td>
+<td>dc=lax host=web2</td>
 <td>0102050102</td>
 </tr>
 <tr class="row-odd"><td>8</td>
 <td>sys.cpu.user</td>
-<td>dc=dal host=web01</td>
+<td>dc=dal host=web1</td>
 <td>0202040101</td>
 </tr>
 <tr class="row-even"><td>9</td>
 <td>sys.cpu.user</td>
-<td>dc=dal host=web02</td>
+<td>dc=dal host=web2</td>
 <td>0202040102</td>
 </tr>
 </tbody>

--- a/docs/source/user_guide/query/examples.rst
+++ b/docs/source/user_guide/query/examples.rst
@@ -12,15 +12,15 @@ Sample Data
    :header: "TS#", "Metric", "Tags", "TSUID"
    :widths: 10, 20, 50, 20
    
-   "1", "sys.cpu.system", "dc=dal host=web01", "0102040101"
-   "2", "sys.cpu.system", "dc=dal host=web02", "0102040102"
-   "3", "sys.cpu.system", "dc=dal host=web03", "0102040103"
+   "1", "sys.cpu.system", "dc=dal host=web1", "0102040101"
+   "2", "sys.cpu.system", "dc=dal host=web2", "0102040102"
+   "3", "sys.cpu.system", "dc=dal host=web3", "0102040103"
    "4", "sys.cpu.system", "host=web01", "010101"
    "5", "sys.cpu.system", "host=web01 owner=jdoe", "0101010306"
-   "6", "sys.cpu.system", "dc=lax host=web01", "0102050101"
-   "7", "sys.cpu.system", "dc=lax host=web02", "0102050102"
-   "8", "sys.cpu.user", "dc=dal host=web01", "0202040101"
-   "9", "sys.cpu.user", "dc=dal host=web02", "0202040102"
+   "6", "sys.cpu.system", "dc=lax host=web1", "0102050101"
+   "7", "sys.cpu.system", "dc=lax host=web2", "0102050102"
+   "8", "sys.cpu.user", "dc=dal host=web1", "0202040101"
+   "9", "sys.cpu.user", "dc=dal host=web2", "0202040102"
    
 **UIDs**
 


### PR DESCRIPTION
Changed web01,web02,web03 to web1,web2,web3 to match rest of documentation. I assume that this is the preferred naming since these are referred to as web1,web2,web3 in the majority of the examples.
