### PR TITLE
Fix typo in news

### DIFF
--- a/content/index.content
+++ b/content/index.content
@@ -60,7 +60,7 @@
     </div>
     <div class="text-center item active">
       <h3>OpenTSDB 2.1 RC1</h3>
-      <p><b>2014-11-09</b> - OpenTSDB 2.1.0 RC 3 has been released with new features. Please download it from <a href="https://github.com/OpenTSDB/opentsdb/releases/tag/v2.1.0RC1">GitHub</a> and help us find bugs! Checkout the new <a href="http://opentsdb.net/docs/build/html/index.html">documentation</a> to find out what's new.</p> 
+      <p><b>2014-11-09</b> - OpenTSDB 2.1.0 RC 1 has been released with new features. Please download it from <a href="https://github.com/OpenTSDB/opentsdb/releases/tag/v2.1.0RC1">GitHub</a> and help us find bugs! Checkout the new <a href="http://opentsdb.net/docs/build/html/index.html">documentation</a> to find out what's new.</p> 
     </div>
     <div class="text-center item">
       <h3>OpenTSDB 2.0</h3>

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
     </div>
     <div class="text-center item active">
       <h3>OpenTSDB 2.1 RC1</h3>
-      <p><b>2014-11-09</b> - OpenTSDB 2.1.0 RC 3 has been released with new features. Please download it from <a href="https://github.com/OpenTSDB/opentsdb/releases/tag/v2.1.0RC1">GitHub</a> and help us find bugs! Checkout the new <a href="http://opentsdb.net/docs/build/html/index.html">documentation</a> to find out what's new.</p> 
+      <p><b>2014-11-09</b> - OpenTSDB 2.1.0 RC 1 has been released with new features. Please download it from <a href="https://github.com/OpenTSDB/opentsdb/releases/tag/v2.1.0RC1">GitHub</a> and help us find bugs! Checkout the new <a href="http://opentsdb.net/docs/build/html/index.html">documentation</a> to find out what's new.</p> 
     </div>
     <div class="text-center item">
       <h3>OpenTSDB 2.0</h3>
@@ -123,7 +123,8 @@
   <a class="right carousel-control" href="#carousel-example-generic" data-slide="next">
     <span class="glyphicon glyphicon-chevron-right"></span>
   </a>
-</div>      <hr>
+</div>
+      <hr>
       <div class="footer">
         <p><a href="https://groups.google.com/forum/#!forum/opentsdb"><i class="glyphicon glyphicon-envelope"></i> Mailing List</a>  | <i class="glyphicon glyphicon-user"></i> IRC: Freenode #opentsdb  |  &copy; 2010 - 2014 The OpenTSDB Authors | Travis CI Status: <img src="https://travis-ci.org/OpenTSDB/opentsdb.svg?branch=master">
       </div>


### PR DESCRIPTION
Just fix the news. It was saying RC 3, while it should be RC 1
