### PR TITLE
fixed documentation for Additional Resources

### DIFF
--- a/docs/build/html/resources.html
+++ b/docs/build/html/resources.html
@@ -104,7 +104,6 @@
 <h2>Docker Images</h2>
 <ul class="simple">
 <li><a class="reference external" href="https://registry.hub.docker.com/u/petergrace/opentsdb-docker/">petergrace/opentsdb-docker</a> - A prebuilt Docker image with HBase and OpenTSDB already configured and ready to run!  If you have Docker installed, execute <code class="docutils literal"><span class="pre">docker</span> <span class="pre">run</span> <span class="pre">-d</span> <span class="pre">-p</span> <span class="pre">4242:4242</span> <span class="pre">petergrace/opentsdb-docker</span></code> to create an opentsdb instance running on port 4242.</li>
-<li><a class="reference external" href="https://registry.hub.docker.com/u/opower/opentsdb/">opower/opentsdb</a> - A Docker image containing OpenTSDB, HBase, and tcollector. Comes in both 2.0.1 and 2.1 versions (latest defaults to 2.1). Execute <code class="docutils literal"><span class="pre">docker</span> <span class="pre">run</span> <span class="pre">-d</span> <span class="pre">-p</span> <span class="pre">4242:4242</span> <span class="pre">opower/opentsdb</span></code> to create an OpenTSDB instance running on port 4242.</li>
 </ul>
 </div>
 <div class="section" id="front-ends">


### PR DESCRIPTION
The link deleted was removed because the link was dead.