### PR TITLE
Added example for using HBase's RegionSplitter CLI

### DIFF
--- a/docs/source/user_guide/writing/index.rst
+++ b/docs/source/user_guide/writing/index.rst
@@ -222,7 +222,9 @@ For brand new installs you will see much better performance if you pre-split the
 
 The simplest way to pre-split your ``tsdb`` table regions is to estimate the number of unique metric names you'll be recording. If you have designed a naming schema, you should have a pretty good idea. Let's say that we will track 4,000 metrics in our system. That's not to say 4,000 time series, as we're not counting the tags yet, just the metric names such as "sys.cpu.user". Data points are written in row keys where the metric's UID comprises the first bytes, 3 bytes by default. The first metric will be assigned a UID of ``000001`` as a hex encoded value. The 4,000th metric will have a UID of ``000FA0`` in hex. You can use these as the start and end keys in the script from the `HBase Book <http://hbase.apache.org/book/perf.writing.html>`_ to split your table into any number of regions. 256 regions may be a good place to start depending on how many time series share each metric.
 
-TODO - include scripts for pre-splitting.
+For example, if you wanted to use ``tsd.storage.salt.buckets = 256`` and create a pre-split table with 256 regions then you can use:
+
+``hbase org.apache.hadoop.hbase.util.RegionSplitter tsdb UniformSplit -c 256 -f t``
 
 The simple split method above assumes that you have roughly an equal number of time series per metric (i.e. a fairly consistent cardinality). E.g. the metric with a UID of ``000001`` may have 200 time series and ``000FA0`` has about 150. If you have a wide range of time series per metric, e.g. ``000001`` has 10,000 time series while ``000FA0`` only has 2, you may need to develop a more complex splitting algorithm.
 


### PR DESCRIPTION
Provided an example of using org.apache.hadoop.hbase.util.RegionSplitter to create a pre-split tsdb table.