### PR TITLE
Fix missing configuration tables

### DIFF
--- a/docs/build/html/user_guide/cli/uid.html
+++ b/docs/build/html/user_guide/cli/uid.html
@@ -146,6 +146,55 @@
 <div class="section" id="common-cli-parameters">
 <h2>Common CLI Parameters</h2>
 <p>Parameters specific to the UID utility include:</p>
+<table class="colwidths-given docutils align-default">
+<colgroup>
+<col style="width: 10%" />
+<col style="width: 10%" />
+<col style="width: 50%" />
+<col style="width: 10%" />
+<col style="width: 20%" />
+</colgroup>
+<thead>
+<tr class="row-odd"><th class="head"><p>Name</p></th>
+<th class="head"><p>Data Type</p></th>
+<th class="head"><p>Description</p></th>
+<th class="head"><p>Default</p></th>
+<th class="head"><p>Example</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="row-even"><td><p>–idwidth</p></td>
+<td><p>Integer</p></td>
+<td><p>Number of bytes on which the UniqueId is encoded. This allows for an override of the built in UID width.</p></td>
+<td><p>3</p></td>
+<td><p>–idwidth=4</p></td>
+</tr>
+<tr class="row-odd"><td><p>–ignore-case</p></td>
+<td><p>Flag</p></td>
+<td><p>Ignore case distinctions when matching on a regular expression using the <code class="docutils literal notranslate"><span class="pre">grep</span></code> sub command</p></td>
+<td></td>
+<td><p>–ignore-case</p></td>
+</tr>
+<tr class="row-even"><td><p>–verbose</p></td>
+<td><p>Flag</p></td>
+<td><p>Print logging messages at level DEBUG and higher. The default is for ERROR and higher to be displayed.</p></td>
+<td></td>
+<td><p>–verbose</p></td>
+</tr>
+<tr class="row-odd"><td><p>-i</p></td>
+<td><p>Flag</p></td>
+<td><p>Short hand for the <code class="docutils literal notranslate"><span class="pre">--ignore-case</span></code> flag</p></td>
+<td></td>
+<td><p>-i</p></td>
+</tr>
+<tr class="row-even"><td><p>-v</p></td>
+<td><p>Flag</p></td>
+<td><p>Short hand for the <code class="docutils literal notranslate"><span class="pre">--verbose</span></code> flag</p></td>
+<td></td>
+<td><p>-v</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="section" id="lookup">
 <h2>Lookup</h2>
@@ -471,6 +520,10 @@
 <p>This command will run through the entire data table, scanning each row of timeseries data and generate missing TSMeta objects and UIDMeta objects or update the created timestamps for each object type if necessary. Use this command after enabling meta tracking with existing data or if you suspect that some timeseries may not have been indexed properly. The command will also push new or updated meta entries to a search engine if a plugin has been configured. If existing meta is corrupted, meaning the TSD is unable to deserialize the object, it will be replaced with a new entry.</p>
 <p>It is safe to run this command at any time as it will not destroy or overwrite valid data. (Unless you modify columns directly in HBase in a manner inconsistent with the meta data formats). The utility will split the data table into chunks processed by multiple threads so the more cores in your processor, the faster the command will complete.</p>
 <div class="section" id="id14">
+<div class="admonition warning">
+<p class="admonition-title">Warning</p>
+<p>Because the entire <code class="docutils literal notranslate"><span class="pre">tsdb</span></code> table is scanned, this command may take a very long time depending on how much data is in your system.</p>
+</div>
 <h3>Command Format</h3>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">metasync</span>
 </pre></div>

--- a/docs/build/html/user_guide/configuration.html
+++ b/docs/build/html/user_guide/configuration.html
@@ -96,7 +96,7 @@ is followed by an equals sign, then the value for the property. All OpenTSDB
 properties start with <code class="docutils literal notranslate"><span class="pre">tsd.</span></code> Comments or inactive configuration lines are
 blocked by a hash symbol <code class="docutils literal notranslate"><span class="pre">#</span></code>. For example:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># List of Zookeeper hosts that manage the HBase cluster</span>
-<span class="n">tsd</span><span class="o">.</span><span class="n">storage</span><span class="o">.</span><span class="n">hbase</span><span class="o">.</span><span class="n">zk_quorum</span> <span class="o">=</span> <span class="mf">192.168</span><span class="o">.</span><span class="mf">1.100</span>
+<span class="n">tsd</span><span class="o">.</span><span class="n">storage</span><span class="o">.</span><span class="n">hbase</span><span class="o">.</span><span class="n">zk_quorum</span> <span class="o">=</span> <span class="mf">192.168.1.100</span>
 </pre></div>
 </div>
 <p>will configure the TSD to connect to Zookeeper on <code class="docutils literal notranslate"><span class="pre">192.168.1.100</span></code>.</p>
@@ -134,6 +134,804 @@ documentation for details.</p>
 <p class="admonition-title">Note</p>
 <p>For additional parameters used for tuning the AsyncHBase client, see <a class="reference external" href="http://opentsdb.github.io/asynchbase/docs/build/html/configuration.html">AsyncHBase Configuration</a></p>
 </div>
+<table class="colwidths-given docutils align-default">
+<colgroup>
+<col style="width: 20%" />
+<col style="width: 5%" />
+<col style="width: 5%" />
+<col style="width: 55%" />
+<col style="width: 5%" />
+<col style="width: 10%" />
+</colgroup>
+<thead>
+<tr class="row-odd"><th class="head"><p>Property</p></th>
+<th class="head"><p>Type</p></th>
+<th class="head"><p>Required</p></th>
+<th class="head"><p>Description</p></th>
+<th class="head"><p>Default</p></th>
+<th class="head"><p>CLI</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="row-even"><td><p>tsd.core.auto_create_metrics</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not a data point with a new metric will assign a UID to the metric. When false, a data point with a metric that is not in the database will be rejected and an exception will be thrown.</p></td>
+<td><p>False</p></td>
+<td><p>–auto-metric</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.auto_create_tagks <em>(2.1)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not a data point with a new tag name will assign a UID to the tagk. When false, a data point with a tag name that is not in the database will be rejected and an exception will be thrown.</p></td>
+<td><p>True</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.core.auto_create_tagvs <em>(2.1)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not a data point with a new tag value will assign a UID to the tagv. When false, a data point with a tag value that is not in the database will be rejected and an exception will be thrown.</p></td>
+<td><p>True</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.connections.limit <em>(2.3)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>Sets the maximum number of connections a TSD will handle, additional connections are immediately closed.</p></td>
+<td><p>0</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.core.enable_api <em>(2.3)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to allow the 2.x HTTP API to function. When disabled, calls to endpoints such as <code class="docutils literal notranslate"><span class="pre">/api/query</span></code> or <code class="docutils literal notranslate"><span class="pre">/api/suggest</span></code> will return a 404.</p></td>
+<td><p>True</p></td>
+<td><p>–disable-api</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.enable_ui <em>(2.3)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to allow the built-in GUI and legacy HTTP API to function. When disabled, calls to the root endpoint or other such as <code class="docutils literal notranslate"><span class="pre">/logs</span></code> or <code class="docutils literal notranslate"><span class="pre">/suggest</span></code> will return a 404.</p></td>
+<td><p>True</p></td>
+<td><p>–disable-ui</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.core.histograms.config <em>(2.4)</em></p></td>
+<td><p>JSON/File Path</p></td>
+<td><p>Optional</p></td>
+<td><p>A mapping of histogram codec class names to numeric identifications for storing multi-measurement data. For simple configurations, the value may be a quote-escaped JSON map, e.g. <code class="docutils literal notranslate"><span class="pre">{&quot;net.opentsdb.core.SimpleHistogramDecoder&quot;:0,</span> <span class="pre">&quot;net.opentsdb.core.CompactQuantilesSketchCodec&quot;:1}</span></code>. If the value ends with <code class="docutils literal notranslate"><span class="pre">.json</span></code> then it will be treated as a file path and the given file will be opened and parsed. Numeric IDs must be between 0 and 255.</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.meta.cache.enable <em>(2.3)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not the meta data caching plugin is enabled.</p></td>
+<td><p>False</p></td>
+<td><p>True</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.core.meta.cache.plugin <em>(2.3)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>The class name of a plugin implementing the meta cache interface.</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.meta.enable_realtime_ts</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable real-time TSMeta object creation. See <a class="reference internal" href="metadata.html"><span class="doc">Metadata</span></a></p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.core.meta.enable_realtime_uid</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable real-time UIDMeta object creation. See <a class="reference internal" href="metadata.html"><span class="doc">Metadata</span></a></p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.meta.enable_tsuid_incrementing</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable tracking of TSUIDs by incrementing a counter every time a data point is recorded. See <a class="reference internal" href="metadata.html"><span class="doc">Metadata</span></a> (Overrides <code class="docutils literal notranslate"><span class="pre">tsd.core.meta.enable_tsuid_tracking</span></code>)</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.core.meta.enable_tsuid_tracking</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable tracking of TSUIDs by storing a <code class="docutils literal notranslate"><span class="pre">1</span></code> with the current timestamp every time a data point is recorded. See <a class="reference internal" href="metadata.html"><span class="doc">Metadata</span></a></p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.plugin_path</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>A path to search for plugins when the TSD starts. If the path is invalid, the TSD will fail to start. Plugins can still be enabled if they are in the class path.</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.core.preload_uid_cache <em>(2.1)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Enables pre-population of the UID caches when starting a TSD.</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.preload_uid_cache.max_entries <em>(2.1)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The number of rows to scan for UID pre-loading.</p></td>
+<td><p>300,000</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.core.stats_with_port <em>(2.3)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to export the listening network port of the TSD as a tag with stats when calling one of the stats endpoints.</p></td>
+<td><p>False</p></td>
+<td><p>True</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.storage_exception_handler.enable <em>(2.2)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable the configured storage exception handler plugin.</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.core.storage_exception_handler.plugin <em>(2.2)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>The full class name of the storage exception handler plugin you wish to use.</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.tag.allow_specialchars <em>(2.3)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>An optional list of ASCII characters allowed in metric names, tag names and tag keys above those already allowed by TSDB. Spaces are allowed.</p></td>
+<td></td>
+<td><p>! ~/</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.core.timezone</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>A localized timezone identification string used to override the local system timezone used when converting absolute times to UTC when executing a query. This does not affect incoming data timestamps. E.g. America/Los_Angeles</p></td>
+<td><p>System Configured</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.tree.enable_processing</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable processing new/edited TSMeta through tree rule sets</p></td>
+<td><p>false</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.core.uid.random_metrics <em>(2.2)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to randomly assign UIDs to new metrics as they are created</p></td>
+<td><p>false</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.bulk.allow_out_of_order_timestamps <a href="#id1"><span class="problematic" id="id2">*</span></a>(2.3.2)</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to allow out-of-order values when bulk importing data from a text file.</p></td>
+<td><p>false</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.core.authentication.enable <a href="#id3"><span class="problematic" id="id4">*</span></a>(2.4)</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable the specified Authentication plugin</p></td>
+<td><p>false</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.core.authentication.plugin <a href="#id5"><span class="problematic" id="id6">*</span></a>(2.4)</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>The class name of an authentication plugin to instantiate. If <code class="docutils literal notranslate"><span class="pre">tsd.core.authentication.enable</span></code> is set to false, this value is ignored.</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.http.cachedir</p></td>
+<td><p>String</p></td>
+<td><p>Required</p></td>
+<td><p>The full path to a location where temporary files can be written. E.g. /tmp/opentsdb</p></td>
+<td></td>
+<td><p>–cachedir</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.http.query.allow_delete</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to allow deleting data points from storage during query time.</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.query.enable_fuzzy_filter</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable the FuzzyRowFilter for HBase when making queries using the <code class="docutils literal notranslate"><span class="pre">explicitTags</span></code> flag.</p></td>
+<td><p>True</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.http.header_tag <em>(2.4)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>An optional HTTP header that, when passed to the HTTP /api/put API, will be extracted and added to the tags of the values posted with the content. Must match an HTTP header exactly.</p></td>
+<td></td>
+<td><p>X-CustomTag</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.http.request.cors_domains</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>A comma separated list of domain names to allow access to OpenTSDB when the <code class="docutils literal notranslate"><span class="pre">Origin</span></code> header is specified by the client. If empty, CORS requests are passed through without validation. The list may not contain the public wildcard <code class="docutils literal notranslate"><span class="pre">*</span></code> and specific domains at the same time.</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.http.request.cors_headers <em>(2.1)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>A comma separated list of headers sent to clients when executing a CORs request. The literal value of this option will be passed to clients.</p></td>
+<td><p>Authorization, Content-Type, Accept, Origin, User-Agent, DNT, Cache-Control, X-Mx-ReqToken, Keep-Alive, X-Requested-With, If-Modified-Since</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.http.request.enable_chunked</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable incoming chunk support for the HTTP RPC</p></td>
+<td><p>false</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.http.request.max_chunk</p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The maximum request body size to support for incoming HTTP requests when chunking is enabled.</p></td>
+<td><p>4096</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.http.rpc.plugins <em>(2.2)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>A comma delimited list of RPC plugins to load when starting a TSD. Must contain the entire class name.</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.http.show_stack_trace</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to return the stack trace with an API query response when an exception occurs.</p></td>
+<td><p>false</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.http.staticroot</p></td>
+<td><p>String</p></td>
+<td><p>Required</p></td>
+<td><p>Location of a directory where static files, such as JavaScript files for the web interface, are located. E.g. /opt/opentsdb/staticroot</p></td>
+<td></td>
+<td><p>–staticroot</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.mode <em>(2.1)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not the TSD will allow writing data points. Must be either <code class="docutils literal notranslate"><span class="pre">rw</span></code> to allow writing data or <code class="docutils literal notranslate"><span class="pre">ro</span></code> to block data point writes. Note that meta data such as UIDs can still be written/modified.</p></td>
+<td><p>rw</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.network.async_io</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to use NIO or traditional blocking IO</p></td>
+<td><p>True</p></td>
+<td><p>–async-io</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.network.backlog</p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The connection queue depth for completed or incomplete connection requests depending on OS. The default may be limited by  the ‘somaxconn’ kernel setting or set by Netty to 3072.</p></td>
+<td><p>See Description</p></td>
+<td><p>–backlog</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.network.bind</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>An IPv4 address to bind to for incoming requests. The default is to listen on all interfaces. E.g. 127.0.0.1</p></td>
+<td><p>0.0.0.0</p></td>
+<td><p>–bind</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.network.keep_alive</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to allow keep-alive connections</p></td>
+<td><p>True</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.network.port</p></td>
+<td><p>Integer</p></td>
+<td><p>Required</p></td>
+<td><p>The TCP port to use for accepting connections</p></td>
+<td></td>
+<td><p>–port</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.network.reuse_address</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to allow reuse of the bound port within Netty</p></td>
+<td><p>True</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.network.tcp_no_delay</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to disable TCP buffering before sending data</p></td>
+<td><p>True</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.network.worker_threads</p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The number of asynchronous IO worker threads for Netty</p></td>
+<td><p><em>#CPU cores * 2</em></p></td>
+<td><p>–worker-threads</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.no_diediedie <em>(2.1)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Enable or disable the <code class="docutils literal notranslate"><span class="pre">diediedie</span></code> HTML and ASCII commands to shutdown a TSD.</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.query.allow_simultaneous_duplicates <em>(2.2)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to allow simultaneous duplicate queries from the same host. If disabled, a second query that comes in matching one already running will receive an exception.</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.query.filter.expansion_limit <em>(2.2)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The maximum number of tag values to include in the regular expression sent to storage during scanning for data. A larger value means more computation on the HBase region servers.</p></td>
+<td><p>4096</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.query.limits.bytes.allow_override, <em>(2.4)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not the query byte limiter can be overiden on a per-query basis.</p></td>
+<td><p>False</p></td>
+<td><p>True</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.query.limits.bytes.default <em>(2.4)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>A limit on the number of bytes fetched from storage. When this limit is hit, the query will return with an exception. A value of <cite>0</cite> disables the limitter.</p></td>
+<td><p>0</p></td>
+<td><p>268435456</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.query.limits.data_points.allow_override <em>(2.4)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not the query data point limiter can be overiden on a per-query basis.</p></td>
+<td><p>False</p></td>
+<td><p>True</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.query.limits.data_points.default <em>(2.4)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>A limit on the number of data points fetched from storage. When this limit is hit, the query will return with an exception. A value of <cite>0</cite> disables the limiter.</p></td>
+<td><p>0</p></td>
+<td><p>1000000</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.query.limits.overrides.interval <em>(2.4)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>How often, in milliseconds, to reload the byte and data point query limiter plugin configuration.</p></td>
+<td><p>60000</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.query.limits.overrides.config <em>(2.4)</em></p></td>
+<td><p>JSON/File Path</p></td>
+<td><p>Optional</p></td>
+<td><p>The path or full config of a query limit configuration with options to match on metric names.</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.query.multi_get.enable <em>(2.4)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not multi-get queries are enabled in conjunction with the search plugin.</p></td>
+<td><p>False</p></td>
+<td><p>True</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.query.multi_get.batch_size <em>(2.4)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The number of <cite>get</cite> requests sent to storage in a single request.</p></td>
+<td><p>1024</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.query.multi_get.concurrent <em>(2.4)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The number of simultaneous batches outstanding at any given time for multi-get queries.</p></td>
+<td><p>20</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.query.multi_get.get_all_salts <em>(2.4)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not a get request is fired for every bucket of salt or if the proper bucket is calculated. Used when salting configurations have changed.</p></td>
+<td><p>False</p></td>
+<td><p>True</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.query.skip_unresolved_tagvs <em>(2.2)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to continue querying when the query includes a tag value that hasn’t been assigned a UID yet and may not exist.</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.query.timeout <em>(2.2)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>How long, in milliseconds, before canceling a running query. A value of 0 means queries will not timeout.</p></td>
+<td><p>0</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.rollups.config <em>(2.4)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>The path to a configuration file detailing available rollup tables and aggregations. Must set <code class="docutils literal notranslate"><span class="pre">tsd.rollups.enable</span></code> to <code class="docutils literal notranslate"><span class="pre">true</span></code> for this option to be parsed. See <a class="reference internal" href="rollups.html"><span class="doc">Rollup And Pre-Aggregates</span></a></p></td>
+<td></td>
+<td><p>rollup_config.json</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.rollups.enable <em>(2.4)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable rollup and pre-aggregation storage and writing.</p></td>
+<td><p>false</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.rollups.tag_raw <em>(2.4)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to tag non-rolled-up and non-pre-aggregated values with the tag key configured in <code class="docutils literal notranslate"><span class="pre">tsd.rollups.agg_tag_key</span></code> and value configured in <code class="docutils literal notranslate"><span class="pre">tsd.rollups.raw_agg_tag_value</span></code></p></td>
+<td><p>false</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.rollups.agg_tag_key <em>(2.4)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>A special key to tag pre-aggregated data with when writing to storage</p></td>
+<td><p>_aggregate</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.rollups.raw_agg_tag_value <em>(2.4)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>A special tag value to non-rolled-up and non-pre-aggregated data with when writing to storage. <code class="docutils literal notranslate"><span class="pre">tsd.rollups.tag_raw</span></code> must be set to true.</p></td>
+<td><p>RAW</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.rollups.split_query.enable <em>(2.4.1)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not queries should merge both rollup and raw data in a single query, particularly when rolledup data is delayed.</p></td>
+<td><p>false</p></td>
+<td><p>“</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.rollups.block_derived <em>(2.4)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to block storing derived aggregations such as <code class="docutils literal notranslate"><span class="pre">AVG</span></code> and <code class="docutils literal notranslate"><span class="pre">DEV</span></code>.</p></td>
+<td><p>true</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.rpc.plugins</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>A comma delimited list of RPC plugins to load when starting a TSD. Must contain the entire class name.</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.rpc.telnet.return_errors <em>(2.4)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to return errors to the Telnet style socket when writing data via <code class="docutils literal notranslate"><span class="pre">put</span></code> or <code class="docutils literal notranslate"><span class="pre">rollup</span></code></p></td>
+<td><p>true</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.rtpublisher.enable</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable a real time publishing plugin. If true, you must supply a valid <code class="docutils literal notranslate"><span class="pre">tsd.rtpublisher.plugin</span></code> class name</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.rtpublisher.plugin</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>The class name of a real time publishing plugin to instantiate. If <code class="docutils literal notranslate"><span class="pre">tsd.rtpublisher.enable</span></code> is set to false, this value is ignored. E.g. net.opentsdb.tsd.RabbitMQPublisher</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.search.enable</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable search functionality. If true, you must supply a valid <code class="docutils literal notranslate"><span class="pre">tsd.search.plugin</span></code> class name</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.search.plugin</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>The class name of a search plugin to instantiate. If <code class="docutils literal notranslate"><span class="pre">tsd.search.enable</span></code> is set to false, this value is ignored. E.g. net.opentsdb.search.ElasticSearch</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.stats.canonical</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not the FQDN should be returned with statistics requests. The default stats are returned with <code class="docutils literal notranslate"><span class="pre">host=&lt;hostname&gt;</span></code> which is not guaranteed to perform a lookup and return the FQDN. Setting this to true will perform a name lookup and return the FQDN if found, otherwise it may return the IP. The stats output should be <code class="docutils literal notranslate"><span class="pre">fqdn=&lt;hostname&gt;</span></code></p></td>
+<td><p>false</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.startup.enable <em>(2.3)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not a startu plugin should be loaded before the TSD.</p></td>
+<td><p>False</p></td>
+<td><p>True</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.startup.plugin <em>(2.3)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>The name of a plugin implementing the <cite>StartupPlugin</cite> interface.</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.compaction.flush_interval <em>(2.2)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>How long, in seconds, to wait in between compaction queue flush calls</p></td>
+<td><p>10</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.compaction.flush_speed <em>(2.2)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>A multiplier used to determine how quickly to attempt flushing the compaction queue. E.g. a value of 2 means it will try to flush the entire queue within 30 minutes. A value of 1 would take an hour.</p></td>
+<td><p>2</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.compaction.max_concurrent_flushes <em>(2.2)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The maximum number of compaction calls inflight to HBase at any given time</p></td>
+<td><p>10000</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.compaction.min_flush_threshold <em>(2.2)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>Size of the compaction queue that must be exceeded before flushing is triggered</p></td>
+<td><p>100</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.enable_appends <em>(2.2)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to append data to columns when writing data points instead of creating new columns for each value. Avoids the need for compactions after each hour but can use more resources on HBase.</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.enable_compaction</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to enable compactions</p></td>
+<td><p>True</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.fix_duplicates <em>(2.1)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to accept the last written value when parsing data points with duplicate timestamps. When enabled in conjunction with compactions, a compacted column will be written with the latest data points.</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.flush_interval</p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>How often, in milliseconds, to flush the data point storage write buffer</p></td>
+<td><p>1000</p></td>
+<td><p>–flush-interval</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.get_date_tiered_compaction_start</p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>A Unix Epoch timestamp in milliseconds when date tierd compactions were enabled on the HBase table. This is useful for existing OpenTSDB installations moving to DTC. Queries starting before this time period will not set time boundaries on queries. See <a class="reference internal" href="tuning.html#date-tierd-compaction"><span class="std std-ref">Date Tierd Compaction</span></a>.</p></td>
+<td><p>0</p></td>
+<td><p>1514764800000</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.hbase.data_table</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>Name of the HBase table where data points are stored</p></td>
+<td><p>tsdb</p></td>
+<td><p>–table</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.hbase.meta_table</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>Name of the HBase table where meta data are stored</p></td>
+<td><p>tsdb-meta</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.hbase.prefetch_meta <em>(2.2)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to prefetch the regions for the TSDB tables before starting the network interface. This can improve performance.</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.hbase.scanner.maxNumRows <em>(2.3)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The maximum number of rows to fetch from HBase per call to the scanner’s <cite>nextRows()</cite> method.</p></td>
+<td><p>128</p></td>
+<td><p>4096</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.hbase.tree_table</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>Name of the HBase table where tree data are stored</p></td>
+<td><p>tsdb-tree</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.hbase.uid_table</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>Name of the HBase table where UID information is stored</p></td>
+<td><p>tsdb-uid</p></td>
+<td><p>–uidtable</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.hbase.zk_basedir</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>Path under which the znode for the -ROOT- region is located</p></td>
+<td><p>/hbase</p></td>
+<td><p>–zkbasedir</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.hbase.zk_quorum</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>A comma-separated list of ZooKeeper hosts to connect to, with or without port specifiers. E.g. <code class="docutils literal notranslate"><span class="pre">192.168.1.1:2181,192.168.1.2:2181</span></code></p></td>
+<td><p>localhost</p></td>
+<td><p>–zkquorum</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.repair_appends <em>(2.2)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to re-write appended data point columns at query time when the columns contain duplicate or out of order data.</p></td>
+<td><p>False</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.max_tags <em>(2.2)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The maximum number of tags allowed per data point. This value can be changed after cluster creation. <strong>NOTE</strong> Please be aware of the performance tradeoffs of overusing tags <span class="xref std std-doc">writing</span></p></td>
+<td><p>8</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.salt.buckets <em>(2.2)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The number of salt buckets used to distribute load across regions. <strong>NOTE</strong> Changing this value after writing data may cause TSUID based queries to fail.</p></td>
+<td><p>20</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.salt.width <em>(2.2)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The width, in bytes, of the salt prefix used to indicate which bucket a time series belongs in. A value of 0 means salting is disabled. <strong>WARNING</strong> Do not change after writing data to HBase or you will corrupt your tables and not be able to query any more.</p></td>
+<td><p>0</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.timeseriesfilter.enable <em>(2.3)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not the data writing filter plugins are enabled.</p></td>
+<td><p>False</p></td>
+<td><p>True</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.timeseriesfilter.plugin <em>(2.3)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>The class path to a plugin that implements the <cite>WriteableDataPointFilterPlugin</cite> interface for filtering time series on writes.</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.uid.width.metric <em>(2.2)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The width, in bytes, of metric UIDs. Maximum value is 7. <strong>WARNING</strong> Do not change after writing data to HBase or you will corrupt your tables and not be able to query any more.</p></td>
+<td><p>3</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.uid.width.tagk <em>(2.2)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The width, in bytes, of tag name UIDs. Maximum value is 7. <strong>WARNING</strong> Do not change after writing data to HBase or you will corrupt your tables and not be able to query any more.</p></td>
+<td><p>3</p></td>
+<td></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.uid.width.tagv <em>(2.2)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The width, in bytes, of tag value UIDs. Maximum value is 7. <strong>WARNING</strong> Do not change after writing data to HBase or you will corrupt your tables and not be able to query any more.</p></td>
+<td><p>3</p></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.storage.use_max_value <em>(2.4)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not to choose the larger numeric value during TSDB compaction when duplicates are found and <cite>tsd.storage.use_otsdb_timestamp</cite> has been set to <cite>true</cite>.</p></td>
+<td><p>True</p></td>
+<td><p>False</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.storage.use_otsdb_timestamp <em>(2.4)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Uses the data point’s timestamp for the edits in storage instead of the default <cite>now</cite>. See <a class="reference internal" href="tuning.html#date-tierd-compaction"><span class="std std-ref">Date Tierd Compaction</span></a>.</p></td>
+<td><p>False</p></td>
+<td><p>True</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.uidfilter.enable <em>(2.3)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not the UID assignment plugin filter is enabled.</p></td>
+<td><p>False</p></td>
+<td><p>True</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.uidfilter.plugin <em>(2.3)</em></p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>A plugin implementing the <cite>UniqueIdFilterPlugin</cite> interface.</p></td>
+<td></td>
+<td></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.uid.lru.enable <em>(2.4)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Changes the UID caches from unbounded maps to LRU caches.</p></td>
+<td><p>False</p></td>
+<td><p>True</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.uid.lru.id.size <em>(2.4)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The total number of entries in the reverse UID to string map. Multiply this by 3 to get the total number of entries available, one per UID type (metric, tag key, tag value).</p></td>
+<td><p>5000000</p></td>
+<td><p>1000000</p></td>
+</tr>
+<tr class="row-odd"><td><p>tsd.uid.lru.name.size <em>(2.4)</em></p></td>
+<td><p>Integer</p></td>
+<td><p>Optional</p></td>
+<td><p>The total number of entries in the forward string to UID map. Multiply this by 3 to get the total number of entries available, one per UID type (metric, tag key, tag value).</p></td>
+<td><p>5000000</p></td>
+<td><p>1000000</p></td>
+</tr>
+<tr class="row-even"><td><p>tsd.uid.use_mode <em>(2.4)</em></p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Determines if the name and/or ID caches should be populated based on the <cite>tsd.mode</cite> setting.</p></td>
+<td><p>False</p></td>
+<td><p>True</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="section" id="data-types">
 <h2>Data Types</h2>

--- a/docs/build/html/user_guide/rollups.html
+++ b/docs/build/html/user_guide/rollups.html
@@ -575,6 +575,61 @@
 <li><p><strong>Rollup Interval</strong> - Any interval with <code class="docutils literal notranslate"><span class="pre">&quot;defaultInterval&quot;:false</span></code> or the default interval not set. These are rollup tables where values are snapped to interval boundaries.</p></li>
 </ul>
 <p>The following fields should be defined:</p>
+<table class="colwidths-given docutils align-default">
+<colgroup>
+<col style="width: 15%" />
+<col style="width: 10%" />
+<col style="width: 5%" />
+<col style="width: 55%" />
+<col style="width: 15%" />
+</colgroup>
+<thead>
+<tr class="row-odd"><th class="head"><p>Name</p></th>
+<th class="head"><p>Data Type</p></th>
+<th class="head"><p>Required</p></th>
+<th class="head"><p>Description</p></th>
+<th class="head"><p>Example</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="row-even"><td><p>table</p></td>
+<td><p>String</p></td>
+<td><p>Required</p></td>
+<td><p>The base or rollup table for non-pre-aggregated data. For the default table, this should be <code class="docutils literal notranslate"><span class="pre">tsdb</span></code> or the table existing raw data is written to. For rolled up data, it must be a different table than the raw data.</p></td>
+<td><p>tsdb-rollup-1h</p></td>
+</tr>
+<tr class="row-odd"><td><p>preAggregationTable</p></td>
+<td><p>String</p></td>
+<td><p>Required</p></td>
+<td><p>The table where pre-aggregated and (optionally) rolled up data should be written to. This may be the same table as the <code class="docutils literal notranslate"><span class="pre">table</span></code> value.</p></td>
+<td><p>tsdb-rollup-preagg-1h</p></td>
+</tr>
+<tr class="row-even"><td><p>interval</p></td>
+<td><p>String</p></td>
+<td><p>Required</p></td>
+<td><p>The expected interval between data points in the format <code class="docutils literal notranslate"><span class="pre">&lt;interval&gt;&lt;units&gt;</span></code>. E.g. if rollups are computed every hour, the interval should be <code class="docutils literal notranslate"><span class="pre">1h</span></code>. If they are computed every 10 minutes, set it to <code class="docutils literal notranslate"><span class="pre">10m</span></code>. For the default table, this value is ignored.</p></td>
+<td><p>1h</p></td>
+</tr>
+<tr class="row-odd"><td><p>rowSpan</p></td>
+<td><p>String</p></td>
+<td><p>Required</p></td>
+<td><p>The width of each row in storage. This value must be greater than the <code class="docutils literal notranslate"><span class="pre">interval</span></code> and defines the number of <code class="docutils literal notranslate"><span class="pre">interval``s</span> <span class="pre">that</span> <span class="pre">will</span> <span class="pre">fit</span> <span class="pre">in</span> <span class="pre">each</span> <span class="pre">row.</span> <span class="pre">E.g.</span> <span class="pre">if</span> <span class="pre">the</span> <span class="pre">interval</span> <span class="pre">is</span> <span class="pre">``1h</span></code> and <code class="docutils literal notranslate"><span class="pre">rowSpan</span></code> is <code class="docutils literal notranslate"><span class="pre">1d</span></code> then we would have 24 values per row.</p></td>
+<td><p>1d</p></td>
+</tr>
+<tr class="row-even"><td><p>defaultInterval</p></td>
+<td><p>Boolean</p></td>
+<td><p>Optional</p></td>
+<td><p>Whether or not the configured interval is the default for raw, non-rolled up data.</p></td>
+<td><p>true</p></td>
+</tr>
+<tr class="row-odd"><td><p>delaySla</p></td>
+<td><p>String</p></td>
+<td><p>Optional</p></td>
+<td><p>An optional delay that accounts for how long it takes to generate and store the rolled up data. Must be a TSD duration</p></td>
+<td><p>2h</p></td>
+</tr>
+</tbody>
+</table>
 <p>In storage, rollups are written similar to the raw data in that each row has a base timestamp and each data point is an offset from that base time. Each offset is an increment off of the base time, not an actual offset. For example, if a row stores 1 day of 1 hour data, there would be up to 24 offsets. Offset <code class="docutils literal notranslate"><span class="pre">0</span></code> would map to midnight for the row and offset 5 would map to 6 AM. Because rollup offsets are encoded on 14 bits, if too many intervals would be stored in a row to fit within 14 bits, an error will be thrown when the TSD is started.</p>
 <div class="admonition warning">
 <p class="admonition-title">Warning</p>

--- a/docs/source/user_guide/cli/uid.rst
+++ b/docs/source/user_guide/cli/uid.rst
@@ -20,7 +20,7 @@ Parameters specific to the UID utility include:
    
    "--idwidth", "Integer", "Number of bytes on which the UniqueId is encoded. This allows for an override of the built in UID width.", "3", "--idwidth=4"
    "--ignore-case", "Flag", "Ignore case distinctions when matching on a regular expression using the ``grep`` sub command", "", "--ignore-case"
-   "--verbose", "Flag", "Print logging messages at level DEBUG and higher. The default is for ERROR and higher to be displayed.", "", ""--verbose"
+   "--verbose", "Flag", "Print logging messages at level DEBUG and higher. The default is for ERROR and higher to be displayed.", "", "--verbose"
    "-i", "Flag", "Short hand for the ``--ignore-case`` flag", "", "-i"
    "-v", "Flag", "Short hand for the ``--verbose`` flag", "", "-v"
 
@@ -225,7 +225,7 @@ This command will run through the entire data table, scanning each row of timese
 
 It is safe to run this command at any time as it will not destroy or overwrite valid data. (Unless you modify columns directly in HBase in a manner inconsistent with the meta data formats). The utility will split the data table into chunks processed by multiple threads so the more cores in your processor, the faster the command will complete.
 
-.. WARN:: Because the entire ``tsdb`` table is scanned, this command may take a very long time depending on how much data is in your system.
+.. WARNING:: Because the entire ``tsdb`` table is scanned, this command may take a very long time depending on how much data is in your system.
 
 Command Format
 --------------

--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -57,6 +57,7 @@ documentation for details.
 .. csv-table::
    :header: "Property", "Type", "Required", "Description", "Default", "CLI"
    :widths: 20, 5, 5, 55, 5, 10
+   :escape: \
 
    "tsd.core.auto_create_metrics", "Boolean", "Optional", "Whether or not a data point with a new metric will assign a UID to the metric. When false, a data point with a metric that is not in the database will be rejected and an exception will be thrown.", "False", "--auto-metric"
    "tsd.core.auto_create_tagks *(2.1)*", "Boolean", "Optional", "Whether or not a data point with a new tag name will assign a UID to the tagk. When false, a data point with a tag name that is not in the database will be rejected and an exception will be thrown.", "True", ""
@@ -64,12 +65,12 @@ documentation for details.
    "tsd.core.connections.limit *(2.3)*", "Integer", "Optional", "Sets the maximum number of connections a TSD will handle, additional connections are immediately closed.", "0", ""
    "tsd.core.enable_api *(2.3)*", "Boolean", "Optional", "Whether or not to allow the 2.x HTTP API to function. When disabled, calls to endpoints such as ``/api/query`` or ``/api/suggest`` will return a 404.", "True", "--disable-api"
    "tsd.core.enable_ui *(2.3)*", "Boolean", "Optional", "Whether or not to allow the built-in GUI and legacy HTTP API to function. When disabled, calls to the root endpoint or other such as ``/logs`` or ``/suggest`` will return a 404.", "True", "--disable-ui"
-   "tsd.core.histograms.config *(2.4)*", "JSON/File Path", "Optional", "A mapping of histogram codec class names to numeric identifications for storing multi-measurement data. For simple configurations, the value may be a quote-escaped JSON map, e.g. ``{\""net.opentsdb.core.SimpleHistogramDecoder\"": 0,\""net.opentsdb.core.CompactQuantilesSketchCodec\"":1}``. If the value ends with ``.json`` then it will be treated as a file path and the given file will be opened and parsed. Numeric IDs must be between 0 and 255.", "", ""
+   "tsd.core.histograms.config *(2.4)*", "JSON/File Path", "Optional", "A mapping of histogram codec class names to numeric identifications for storing multi-measurement data. For simple configurations, the value may be a quote-escaped JSON map, e.g. ``{\"net.opentsdb.core.SimpleHistogramDecoder\":0, \"net.opentsdb.core.CompactQuantilesSketchCodec\":1}``. If the value ends with ``.json`` then it will be treated as a file path and the given file will be opened and parsed. Numeric IDs must be between 0 and 255.", "", ""
    "tsd.core.meta.cache.enable *(2.3)*", "Boolean", "Optional", "Whether or not the meta data caching plugin is enabled.", "False", "True"
    "tsd.core.meta.cache.plugin *(2.3)*", "String", "Optional", "The class name of a plugin implementing the meta cache interface.", "", ""
    "tsd.core.meta.enable_realtime_ts", "Boolean", "Optional", "Whether or not to enable real-time TSMeta object creation. See :doc:`../user_guide/metadata`", "False", ""
    "tsd.core.meta.enable_realtime_uid", "Boolean", "Optional", "Whether or not to enable real-time UIDMeta object creation. See :doc:`../user_guide/metadata`", "False", ""
-   "tsd.core.meta.enable_tsuid_incrementing", "Boolean", "Optional", "Whether or not to enable tracking of TSUIDs by incrementing a counter every time a data point is recorded. See :doc:`../user_guide/metadata` (Overrides ""tsd.core.meta.enable_tsuid_tracking"")", "False", ""
+   "tsd.core.meta.enable_tsuid_incrementing", "Boolean", "Optional", "Whether or not to enable tracking of TSUIDs by incrementing a counter every time a data point is recorded. See :doc:`../user_guide/metadata` (Overrides ``tsd.core.meta.enable_tsuid_tracking``)", "False", ""
    "tsd.core.meta.enable_tsuid_tracking", "Boolean", "Optional", "Whether or not to enable tracking of TSUIDs by storing a ``1`` with the current timestamp every time a data point is recorded. See :doc:`../user_guide/metadata`", "False", ""
    "tsd.core.plugin_path", "String", "Optional", "A path to search for plugins when the TSD starts. If the path is invalid, the TSD will fail to start. Plugins can still be enabled if they are in the class path.", "", ""
    "tsd.core.preload_uid_cache *(2.1)*", "Boolean", "Optional", "Enables pre-population of the UID caches when starting a TSD.", "False", ""
@@ -77,16 +78,14 @@ documentation for details.
    "tsd.core.stats_with_port *(2.3)*", "Boolean", "Optional", "Whether or not to export the listening network port of the TSD as a tag with stats when calling one of the stats endpoints.", "False", "True"
    "tsd.core.storage_exception_handler.enable *(2.2)*", "Boolean", "Optional", "Whether or not to enable the configured storage exception handler plugin.", "False", ""
    "tsd.core.storage_exception_handler.plugin *(2.2)*", "String", "Optional", "The full class name of the storage exception handler plugin you wish to use.", "", ""
-   "tsd.core.tag.allow_specialchars *(2.3)*", "String", "Optional", "An optional list of ASCII characters allowed in metric names, tag names and tag keys above those already allowed by TSDB. Spaces are allowed.", "", "! ~/\"
-   "tsd.core.timezone", "String", "Optional", "A localized timezone identification string used to override the local system timezone used when converting absolute times to UTC when executing a query. This does not affect incoming data timestamps.
-   E.g. America/Los_Angeles", "System Configured", ""
+   "tsd.core.tag.allow_specialchars *(2.3)*", "String", "Optional", "An optional list of ASCII characters allowed in metric names, tag names and tag keys above those already allowed by TSDB. Spaces are allowed.", "", "! ~/\\"
+   "tsd.core.timezone", "String", "Optional", "A localized timezone identification string used to override the local system timezone used when converting absolute times to UTC when executing a query. This does not affect incoming data timestamps. E.g. America/Los_Angeles", "System Configured", ""
    "tsd.core.tree.enable_processing", "Boolean", "Optional", "Whether or not to enable processing new/edited TSMeta through tree rule sets", "false", ""
    "tsd.core.uid.random_metrics *(2.2)*", "Boolean", "Optional", "Whether or not to randomly assign UIDs to new metrics as they are created", "false", ""
    "tsd.core.bulk.allow_out_of_order_timestamps *(2.3.2)", "Boolean", "Optional", "Whether or not to allow out-of-order values when bulk importing data from a text file.", "false", ""
    "tsd.core.authentication.enable *(2.4)", "Boolean", "Optional", "Whether or not to enable the specified Authentication plugin", "false", ""
    "tsd.core.authentication.plugin *(2.4)", "String", "Optional", "The class name of an authentication plugin to instantiate. If ``tsd.core.authentication.enable`` is set to false, this value is ignored.", "", ""
-   "tsd.http.cachedir", "String", "Required", "The full path to a location where temporary files can be written.
-   E.g. /tmp/opentsdb", "", "--cachedir"
+   "tsd.http.cachedir", "String", "Required", "The full path to a location where temporary files can be written. E.g. /tmp/opentsdb", "", "--cachedir"
    "tsd.http.query.allow_delete", "Boolean", "Optional", "Whether or not to allow deleting data points from storage during query time.", "False", ""
    "tsd.query.enable_fuzzy_filter", "Boolean", "Optional", "Whether or not to enable the FuzzyRowFilter for HBase when making queries using the ``explicitTags`` flag.", "True", ""
    "tsd.http.header_tag *(2.4)*", "String", "Optional", "An optional HTTP header that, when passed to the HTTP /api/put API, will be extracted and added to the tags of the values posted with the content. Must match an HTTP header exactly.", "", "X-CustomTag"
@@ -96,13 +95,11 @@ documentation for details.
    "tsd.http.request.max_chunk", "Integer", "Optional", "The maximum request body size to support for incoming HTTP requests when chunking is enabled.", "4096", ""
    "tsd.http.rpc.plugins *(2.2)*", "String", "Optional", "A comma delimited list of RPC plugins to load when starting a TSD. Must contain the entire class name.", "", ""
    "tsd.http.show_stack_trace", "Boolean", "Optional", "Whether or not to return the stack trace with an API query response when an exception occurs.", "false", ""
-   "tsd.http.staticroot", "String", "Required", "Location of a directory where static files, such as JavaScript files for the web interface, are located.
-   E.g. /opt/opentsdb/staticroot", "", "--staticroot"
+   "tsd.http.staticroot", "String", "Required", "Location of a directory where static files, such as JavaScript files for the web interface, are located. E.g. /opt/opentsdb/staticroot", "", "--staticroot"
    "tsd.mode *(2.1)*", "String", "Optional", "Whether or not the TSD will allow writing data points. Must be either ``rw`` to allow writing data or ``ro`` to block data point writes. Note that meta data such as UIDs can still be written/modified.", "rw", ""
    "tsd.network.async_io", "Boolean", "Optional", "Whether or not to use NIO or traditional blocking IO", "True", "--async-io"
    "tsd.network.backlog", "Integer", "Optional", "The connection queue depth for completed or incomplete connection requests depending on OS. The default may be limited by  the 'somaxconn' kernel setting or set by Netty to 3072.", "See Description", "--backlog"
-   "tsd.network.bind", "String", "Optional", "An IPv4 address to bind to for incoming requests. The default is to listen on all interfaces.
-   E.g. 127.0.0.1", "0.0.0.0", "--bind"
+   "tsd.network.bind", "String", "Optional", "An IPv4 address to bind to for incoming requests. The default is to listen on all interfaces. E.g. 127.0.0.1", "0.0.0.0", "--bind"
    "tsd.network.keep_alive", "Boolean", "Optional", "Whether or not to allow keep-alive connections", "True", ""
    "tsd.network.port", "Integer", "Required", "The TCP port to use for accepting connections", "", "--port"
    "tsd.network.reuse_address", "Boolean", "Optional", "Whether or not to allow reuse of the bound port within Netty", "True", ""
@@ -128,17 +125,14 @@ documentation for details.
    "tsd.rollups.tag_raw *(2.4)*", "Boolean", "Optional", "Whether or not to tag non-rolled-up and non-pre-aggregated values with the tag key configured in ``tsd.rollups.agg_tag_key`` and value configured in ``tsd.rollups.raw_agg_tag_value``", "false", ""
    "tsd.rollups.agg_tag_key *(2.4)*", "String", "Optional", "A special key to tag pre-aggregated data with when writing to storage", "_aggregate", ""
    "tsd.rollups.raw_agg_tag_value *(2.4)*", "String", "Optional", "A special tag value to non-rolled-up and non-pre-aggregated data with when writing to storage. ``tsd.rollups.tag_raw`` must be set to true.", "RAW", ""
-   "tsd.rollups.split_query.enable *(2.4.1)*", "Boolean", "Optional", "Whether or not queries should merge both rollup and raw data in a single query,
-   particularly when rolledup data is delayed.", "false", """
+   "tsd.rollups.split_query.enable *(2.4.1)*", "Boolean", "Optional", "Whether or not queries should merge both rollup and raw data in a single query, particularly when rolledup data is delayed.", "false", """
    "tsd.rollups.block_derived *(2.4)*", "Boolean", "Optional", "Whether or not to block storing derived aggregations such as ``AVG`` and ``DEV``.", "true", ""
    "tsd.rpc.plugins", "String", "Optional", "A comma delimited list of RPC plugins to load when starting a TSD. Must contain the entire class name.", "", ""
    "tsd.rpc.telnet.return_errors *(2.4)*", "Boolean", "Optional", "Whether or not to return errors to the Telnet style socket when writing data via ``put`` or ``rollup``", "true", ""
    "tsd.rtpublisher.enable", "Boolean", "Optional", "Whether or not to enable a real time publishing plugin. If true, you must supply a valid ``tsd.rtpublisher.plugin`` class name", "False", ""
-   "tsd.rtpublisher.plugin", "String", "Optional", "The class name of a real time publishing plugin to instantiate. If ``tsd.rtpublisher.enable`` is set to false, this value is ignored.
-   E.g. net.opentsdb.tsd.RabbitMQPublisher", "", ""
+   "tsd.rtpublisher.plugin", "String", "Optional", "The class name of a real time publishing plugin to instantiate. If ``tsd.rtpublisher.enable`` is set to false, this value is ignored. E.g. net.opentsdb.tsd.RabbitMQPublisher", "", ""
    "tsd.search.enable", "Boolean", "Optional", "Whether or not to enable search functionality. If true, you must supply a valid ``tsd.search.plugin`` class name", "False", ""
-   "tsd.search.plugin", "String", "Optional", "The class name of a search plugin to instantiate. If ``tsd.search.enable`` is set to false, this value is ignored.
-   E.g. net.opentsdb.search.ElasticSearch", "", ""
+   "tsd.search.plugin", "String", "Optional", "The class name of a search plugin to instantiate. If ``tsd.search.enable`` is set to false, this value is ignored. E.g. net.opentsdb.search.ElasticSearch", "", ""
    "tsd.stats.canonical", "Boolean", "Optional", "Whether or not the FQDN should be returned with statistics requests. The default stats are returned with ``host=<hostname>`` which is not guaranteed to perform a lookup and return the FQDN. Setting this to true will perform a name lookup and return the FQDN if found, otherwise it may return the IP. The stats output should be ``fqdn=<hostname>``", "false", ""
    "tsd.startup.enable *(2.3)*", "Boolean", "Optional", "Whether or not a startu plugin should be loaded before the TSD.", "False", "True"
    "tsd.startup.plugin *(2.3)*", "String", "Optional", "The name of a plugin implementing the `StartupPlugin` interface.", "", ""
@@ -168,7 +162,7 @@ documentation for details.
    "tsd.storage.uid.width.metric *(2.2)*", "Integer", "Optional", "The width, in bytes, of metric UIDs. Maximum value is 7. **WARNING** Do not change after writing data to HBase or you will corrupt your tables and not be able to query any more.", "3", ""
    "tsd.storage.uid.width.tagk *(2.2)*", "Integer", "Optional", "The width, in bytes, of tag name UIDs. Maximum value is 7. **WARNING** Do not change after writing data to HBase or you will corrupt your tables and not be able to query any more.", "3", ""
    "tsd.storage.uid.width.tagv *(2.2)*", "Integer", "Optional", "The width, in bytes, of tag value UIDs. Maximum value is 7. **WARNING** Do not change after writing data to HBase or you will corrupt your tables and not be able to query any more.", "3", ""
-	"tsd.storage.use_max_value *(2.4)*", "Boolean", "Optional", "Whether or not to choose the larger numeric value during TSDB compaction when duplicates are found and `tsd.storage.use_otsdb_timestamp` has been set to `true`.", "True", "False"
+   "tsd.storage.use_max_value *(2.4)*", "Boolean", "Optional", "Whether or not to choose the larger numeric value during TSDB compaction when duplicates are found and `tsd.storage.use_otsdb_timestamp` has been set to `true`.", "True", "False"
    "tsd.storage.use_otsdb_timestamp *(2.4)*", "Boolean", "Optional", "Uses the data point's timestamp for the edits in storage instead of the default `now`. See :ref:`date_tierd_compaction`.", "False", "True"
    "tsd.uidfilter.enable *(2.3)*", "Boolean", "Optional", "Whether or not the UID assignment plugin filter is enabled.", "False", "True"
    "tsd.uidfilter.plugin *(2.3)*", "String", "Optional", "A plugin implementing the `UniqueIdFilterPlugin` interface.", "", ""

--- a/docs/source/user_guide/rollups.rst
+++ b/docs/source/user_guide/rollups.rst
@@ -275,7 +275,7 @@ The following fields should be defined:
    "interval", "String", "Required", "The expected interval between data points in the format ``<interval><units>``. E.g. if rollups are computed every hour, the interval should be ``1h``. If they are computed every 10 minutes, set it to ``10m``. For the default table, this value is ignored.", "1h"
    "rowSpan", "String", "Required", "The width of each row in storage. This value must be greater than the ``interval`` and defines the number of ``interval``s that will fit in each row. E.g. if the interval is ``1h`` and ``rowSpan`` is ``1d`` then we would have 24 values per row.", "1d"
    "defaultInterval", "Boolean", "Optional", "Whether or not the configured interval is the default for raw, non-rolled up data.", "true"
-   "delaySla", "String", "Optional", "An optional delay that accounts for how long it takes to generate and store the rolled up data. Must be a TSD duration", "", "2h"
+   "delaySla", "String", "Optional", "An optional delay that accounts for how long it takes to generate and store the rolled up data. Must be a TSD duration", "2h"
 
 In storage, rollups are written similar to the raw data in that each row has a base timestamp and each data point is an offset from that base time. Each offset is an increment off of the base time, not an actual offset. For example, if a row stores 1 day of 1 hour data, there would be up to 24 offsets. Offset ``0`` would map to midnight for the row and offset 5 would map to 6 AM. Because rollup offsets are encoded on 14 bits, if too many intervals would be stored in a row to fit within 14 bits, an error will be thrown when the TSD is started. 
 


### PR DESCRIPTION
At [this commit](https://github.com/OpenTSDB/opentsdb.net/commit/4e467c71816acdcba4b0849baa8b34c40f8ab484), some configuration tables have been disappeared due to invalid "csv-table" directive. 

Here's the problem pages.
* http://opentsdb.net/docs/build/html/user_guide/configuration.html
* http://opentsdb.net/docs/build/html/user_guide/rollups.html
* http://opentsdb.net/docs/build/html/user_guide/cli/index.html