### PR TITLE
fix default auto interval for 3x

### DIFF
--- a/docs/3x/build/html/user_guide/semanticquery/downsample.html
+++ b/docs/3x/build/html/user_guide/semanticquery/downsample.html
@@ -301,14 +301,14 @@
 </div>
 <div class="section" id="auto-intervals">
 <h2>Auto Intervals</h2>
-<p>When <code class="docutils literal notranslate"><span class="pre">auto</span></code> is used in the interval and configured in the TSD, the TSD will take the start and end time of the query and compute a downsample that would return at most about 400 data points for the query range. A stepping configuration is used to determine the final resolution. By default, this stepping config is:</p>
+<p>When <code class="docutils literal notranslate"><span class="pre">auto</span></code> is used in the interval and configured in the TSD, the TSD will take the start and end time of the query and compute a downsample that would return at most about 800 data points for the query range. A stepping configuration is used to determine the final resolution. By default, this stepping config is:</p>
 <ul class="simple">
-<li><p>&lt; 6h use <code class="docutils literal notranslate"><span class="pre">1m</span></code></p></li>
-<li><p>&gt;= 6h and &lt; 12h use <code class="docutils literal notranslate"><span class="pre">15m</span></code></p></li>
-<li><p>&gt;= 12h and &lt; 3d use <code class="docutils literal notranslate"><span class="pre">1h</span></code></p></li>
-<li><p>&gt;= 3d and &lt; 1w use <code class="docutils literal notranslate"><span class="pre">6h</span></code></p></li>
-<li><p>&gt;= 1w and &lt; 1 month use <code class="docutils literal notranslate"><span class="pre">1d</span></code></p></li>
-<li><p>&gt;= 1 month use <code class="docutils literal notranslate"><span class="pre">1w</span></code></p></li>
+<li><p>&lt; 12h use <code class="docutils literal notranslate"><span class="pre">1m</span></code></p></li>
+<li><p>&gt;= 12h and &lt; 3d use <code class="docutils literal notranslate"><span class="pre">15m</span></code></p></li>
+<li><p>&gt;= 3d and &lt; 1w use <code class="docutils literal notranslate"><span class="pre">1h</span></code></p></li>
+<li><p>&gt;= 1w and &lt; 1 month use <code class="docutils literal notranslate"><span class="pre">6h</span></code></p></li>
+<li><p>&gt;= 1 month &lt; 1 year use <code class="docutils literal notranslate"><span class="pre">1d</span></code></p></li>
+<li><p>&gt;= 1 year use <code class="docutils literal notranslate"><span class="pre">1w</span></code></p></li>
 </ul>
 <p>To override this configuration, use the <code class="docutils literal notranslate"><span class="pre">tsd.query.downsample.auto.config</span></code> property. An example looks like:</p>
 <div class="highlight-javascript notranslate"><div class="highlight"><pre><span></span># ---------- DOWNSAMPLE ----------

--- a/docs/3x/source/user_guide/semanticquery/downsample.rst
+++ b/docs/3x/source/user_guide/semanticquery/downsample.rst
@@ -64,14 +64,14 @@ When downsampling is present, a time specifications will be serialized in the ou
 Auto Intervals
 --------------
 
-When ``auto`` is used in the interval and configured in the TSD, the TSD will take the start and end time of the query and compute a downsample that would return at most about 400 data points for the query range. A stepping configuration is used to determine the final resolution. By default, this stepping config is:
+When ``auto`` is used in the interval and configured in the TSD, the TSD will take the start and end time of the query and compute a downsample that would return at most about 800 data points for the query range. A stepping configuration is used to determine the final resolution. By default, this stepping config is:
 
-* < 6h use ``1m``
-* >= 6h and < 12h use ``15m``
-* >= 12h and < 3d use ``1h``
-* >= 3d and < 1w use ``6h``
-* >= 1w and < 1 month use ``1d``
-* >= 1 month use ``1w``
+* < 12h use ``1m``
+* >= 12h and < 3d use ``15m``
+* >= 3d and < 1w use ``1h``
+* >= 1w and < 1 month use ``6h``
+* >= 1 month < 1 year use ``1d``
+* >= 1 year use ``1w``
 
 To override this configuration, use the ``tsd.query.downsample.auto.config`` property. An example looks like:
 


### PR DESCRIPTION
Fixed the description of the default value of auto intervals because it differs from the 3.x implementation.

https://github.com/OpenTSDB/opentsdb/blob/628bc6ee962293bb94ff531be671d9004e49db50/core/src/main/java/net/opentsdb/query/processor/downsample/DownsampleFactory.java#L108-L116