### PR TITLE
fix wrong timestamp appeared in the downsampling

### DIFF
--- a/docs/3x/build/html/_sources/admin_guide/query/downsampling.rst.txt
+++ b/docs/3x/build/html/_sources/admin_guide/query/downsampling.rst.txt
@@ -65,4 +65,4 @@ In this example we have data reported every 10 seconds and we want to enforce a 
    "B ``sum`` Downsampled", "10", "NaN", "20", "NaN", "NaN", "NaN", "20"
    "``sum`` Aggregated Result", "10", "NaN", "20", "15", "NaN", "5", "20"
 
-If we requested the output without a fill policy, no value or timestamp at ``t0+20s`` or ``t0+40s`` would be emitted. Additionally, values at ``t0+30s`` and ``t0+50s`` for series ``B`` would be linearly interpolated to fill in values to be summed with series ``A``.
+If we requested the output without a fill policy, no value or timestamp at ``t0+10s`` or ``t0+40s`` would be emitted. Additionally, values at ``t0+30s`` and ``t0+50s`` for series ``B`` would be linearly interpolated to fill in values to be summed with series ``A``.

--- a/docs/3x/build/html/_sources/user_guide/query/downsampling.rst.txt
+++ b/docs/3x/build/html/_sources/user_guide/query/downsampling.rst.txt
@@ -65,4 +65,4 @@ In this example we have data reported every 10 seconds and we want to enforce a 
    "B ``sum`` Downsampled", "10", "NaN", "20", "NaN", "NaN", "NaN", "20"
    "``sum`` Aggregated Result", "10", "NaN", "20", "15", "NaN", "5", "20"
 
-If we requested the output without a fill policy, no value or timestamp at ``t0+20s`` or ``t0+40s`` would be emitted. Additionally, values at ``t0+30s`` and ``t0+50s`` for series ``B`` would be linearly interpolated to fill in values to be summed with series ``A``.
+If we requested the output without a fill policy, no value or timestamp at ``t0+10s`` or ``t0+40s`` would be emitted. Additionally, values at ``t0+30s`` and ``t0+50s`` for series ``B`` would be linearly interpolated to fill in values to be summed with series ``A``.

--- a/docs/3x/build/html/admin_guide/query/downsampling.html
+++ b/docs/3x/build/html/admin_guide/query/downsampling.html
@@ -315,7 +315,7 @@
 </tr>
 </tbody>
 </table>
-<p>If we requested the output without a fill policy, no value or timestamp at <code class="docutils literal notranslate"><span class="pre">t0+20s</span></code> or <code class="docutils literal notranslate"><span class="pre">t0+40s</span></code> would be emitted. Additionally, values at <code class="docutils literal notranslate"><span class="pre">t0+30s</span></code> and <code class="docutils literal notranslate"><span class="pre">t0+50s</span></code> for series <code class="docutils literal notranslate"><span class="pre">B</span></code> would be linearly interpolated to fill in values to be summed with series <code class="docutils literal notranslate"><span class="pre">A</span></code>.</p>
+<p>If we requested the output without a fill policy, no value or timestamp at <code class="docutils literal notranslate"><span class="pre">t0+10s</span></code> or <code class="docutils literal notranslate"><span class="pre">t0+40s</span></code> would be emitted. Additionally, values at <code class="docutils literal notranslate"><span class="pre">t0+30s</span></code> and <code class="docutils literal notranslate"><span class="pre">t0+50s</span></code> for series <code class="docutils literal notranslate"><span class="pre">B</span></code> would be linearly interpolated to fill in values to be summed with series <code class="docutils literal notranslate"><span class="pre">A</span></code>.</p>
 </div>
 </div>
 

--- a/docs/3x/build/html/user_guide/query/downsampling.html
+++ b/docs/3x/build/html/user_guide/query/downsampling.html
@@ -311,7 +311,7 @@
 </tr>
 </tbody>
 </table>
-<p>If we requested the output without a fill policy, no value or timestamp at <code class="docutils literal"><span class="pre">t0+20s</span></code> or <code class="docutils literal"><span class="pre">t0+40s</span></code> would be emitted. Additionally, values at <code class="docutils literal"><span class="pre">t0+30s</span></code> and <code class="docutils literal"><span class="pre">t0+50s</span></code> for series <code class="docutils literal"><span class="pre">B</span></code> would be linearly interpolated to fill in values to be summed with series <code class="docutils literal"><span class="pre">A</span></code>.</p>
+<p>If we requested the output without a fill policy, no value or timestamp at <code class="docutils literal"><span class="pre">t0+10s</span></code> or <code class="docutils literal"><span class="pre">t0+40s</span></code> would be emitted. Additionally, values at <code class="docutils literal"><span class="pre">t0+30s</span></code> and <code class="docutils literal"><span class="pre">t0+50s</span></code> for series <code class="docutils literal"><span class="pre">B</span></code> would be linearly interpolated to fill in values to be summed with series <code class="docutils literal"><span class="pre">A</span></code>.</p>
 </div>
 </div>
 

--- a/docs/3x/source/admin_guide/query/downsampling.rst
+++ b/docs/3x/source/admin_guide/query/downsampling.rst
@@ -65,4 +65,4 @@ In this example we have data reported every 10 seconds and we want to enforce a 
    "B ``sum`` Downsampled", "10", "NaN", "20", "NaN", "NaN", "NaN", "20"
    "``sum`` Aggregated Result", "10", "NaN", "20", "15", "NaN", "5", "20"
 
-If we requested the output without a fill policy, no value or timestamp at ``t0+20s`` or ``t0+40s`` would be emitted. Additionally, values at ``t0+30s`` and ``t0+50s`` for series ``B`` would be linearly interpolated to fill in values to be summed with series ``A``.
+If we requested the output without a fill policy, no value or timestamp at ``t0+10s`` or ``t0+40s`` would be emitted. Additionally, values at ``t0+30s`` and ``t0+50s`` for series ``B`` would be linearly interpolated to fill in values to be summed with series ``A``.

--- a/docs/build/html/_sources/user_guide/query/downsampling.rst.txt
+++ b/docs/build/html/_sources/user_guide/query/downsampling.rst.txt
@@ -65,4 +65,4 @@ In this example we have data reported every 10 seconds and we want to enforce a 
    "B ``sum`` Downsampled", "10", "NaN", "20", "NaN", "NaN", "NaN", "20"
    "``sum`` Aggregated Result", "10", "NaN", "20", "15", "NaN", "5", "20"
 
-If we requested the output without a fill policy, no value or timestamp at ``t0+20s`` or ``t0+40s`` would be emitted. Additionally, values at ``t0+30s`` and ``t0+50s`` for series ``B`` would be linearly interpolated to fill in values to be summed with series ``A``.
+If we requested the output without a fill policy, no value or timestamp at ``t0+10s`` or ``t0+40s`` would be emitted. Additionally, values at ``t0+30s`` and ``t0+50s`` for series ``B`` would be linearly interpolated to fill in values to be summed with series ``A``.

--- a/docs/build/html/user_guide/query/downsampling.html
+++ b/docs/build/html/user_guide/query/downsampling.html
@@ -258,7 +258,7 @@
 </tr>
 </tbody>
 </table>
-<p>If we requested the output without a fill policy, no value or timestamp at <code class="docutils literal notranslate"><span class="pre">t0+20s</span></code> or <code class="docutils literal notranslate"><span class="pre">t0+40s</span></code> would be emitted. Additionally, values at <code class="docutils literal notranslate"><span class="pre">t0+30s</span></code> and <code class="docutils literal notranslate"><span class="pre">t0+50s</span></code> for series <code class="docutils literal notranslate"><span class="pre">B</span></code> would be linearly interpolated to fill in values to be summed with series <code class="docutils literal notranslate"><span class="pre">A</span></code>.</p>
+<p>If we requested the output without a fill policy, no value or timestamp at <code class="docutils literal notranslate"><span class="pre">t0+10s</span></code> or <code class="docutils literal notranslate"><span class="pre">t0+40s</span></code> would be emitted. Additionally, values at <code class="docutils literal notranslate"><span class="pre">t0+30s</span></code> and <code class="docutils literal notranslate"><span class="pre">t0+50s</span></code> for series <code class="docutils literal notranslate"><span class="pre">B</span></code> would be linearly interpolated to fill in values to be summed with series <code class="docutils literal notranslate"><span class="pre">A</span></code>.</p>
 </div>
 </div>
 

--- a/docs/source/user_guide/query/downsampling.rst
+++ b/docs/source/user_guide/query/downsampling.rst
@@ -65,4 +65,4 @@ In this example we have data reported every 10 seconds and we want to enforce a 
    "B ``sum`` Downsampled", "10", "NaN", "20", "NaN", "NaN", "NaN", "20"
    "``sum`` Aggregated Result", "10", "NaN", "20", "15", "NaN", "5", "20"
 
-If we requested the output without a fill policy, no value or timestamp at ``t0+20s`` or ``t0+40s`` would be emitted. Additionally, values at ``t0+30s`` and ``t0+50s`` for series ``B`` would be linearly interpolated to fill in values to be summed with series ``A``.
+If we requested the output without a fill policy, no value or timestamp at ``t0+10s`` or ``t0+40s`` would be emitted. Additionally, values at ``t0+30s`` and ``t0+50s`` for series ``B`` would be linearly interpolated to fill in values to be summed with series ``A``.


### PR DESCRIPTION
I think the point in time when no value appears is `t0+10s`
![image](https://user-images.githubusercontent.com/2959046/144980441-ebbbcfc6-0d50-47c6-b437-4a1976d4a4b2.png)
